### PR TITLE
Update branch in protection rules

### DIFF
--- a/otterdog/eclipse-sisu.jsonnet
+++ b/otterdog/eclipse-sisu.jsonnet
@@ -39,7 +39,7 @@ orgs.newOrg('technology.sisu', 'eclipse-sisu') {
         default_workflow_permissions: "write",
       },
       branch_protection_rules: [
-        orgs.newBranchProtectionRule('master') {
+        orgs.newBranchProtectionRule('main') {
           lock_branch: true,
         }
       ],


### PR DESCRIPTION
We are on main branch but protection rules were still protecting old (and obsolete) master. In fact, to avoid any confusion, we'd like to drop master once rules are set to proper branch.