### PR TITLE
Undo PR 11

### DIFF
--- a/otterdog/eclipse-sisu.jsonnet
+++ b/otterdog/eclipse-sisu.jsonnet
@@ -41,6 +41,7 @@ orgs.newOrg('technology.sisu', 'eclipse-sisu') {
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
           lock_branch: false,
+          requires_pull_request: false,
           required_approving_review_count: 1,
         }
       ],

--- a/otterdog/eclipse-sisu.jsonnet
+++ b/otterdog/eclipse-sisu.jsonnet
@@ -40,7 +40,7 @@ orgs.newOrg('technology.sisu', 'eclipse-sisu') {
       },
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
-          lock_branch: true,
+          lock_branch: false,
         }
       ],
     },

--- a/otterdog/eclipse-sisu.jsonnet
+++ b/otterdog/eclipse-sisu.jsonnet
@@ -41,6 +41,7 @@ orgs.newOrg('technology.sisu', 'eclipse-sisu') {
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
           lock_branch: false,
+          required_approving_review_count: 1,
         }
       ],
     },

--- a/otterdog/eclipse-sisu.jsonnet
+++ b/otterdog/eclipse-sisu.jsonnet
@@ -40,9 +40,7 @@ orgs.newOrg('technology.sisu', 'eclipse-sisu') {
       },
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
-          lock_branch: false,
-          requires_pull_request: true,
-          required_approving_review_count: 1,
+          lock_branch: true,
         }
       ],
     },


### PR DESCRIPTION
For now we must be able to push (not force) to main as this is how Maven Resolver Plugin works.

Currently Sisu 1.0.1 is being synced to Central but changes cannot be pushed to main due this.

Undoing PR #11 for now.